### PR TITLE
Fix off-by-one error when declaring the RF_Shadow register array.

### DIFF
--- a/hal/rtl8192c/rtl8192c_rf6052.c
+++ b/hal/rtl8192c/rtl8192c_rf6052.c
@@ -72,7 +72,7 @@ typedef struct RF_Shadow_Compare_Map {
 /*------------------------Define local variable------------------------------*/
 // 2008/11/20 MH For Debug only, RF
 //static	RF_SHADOW_T	RF_Shadow[RF6052_MAX_PATH][RF6052_MAX_REG] = {0};
-static	RF_SHADOW_T	RF_Shadow[RF6052_MAX_PATH][RF6052_MAX_REG];
+static	RF_SHADOW_T	RF_Shadow[RF6052_MAX_PATH][RF6052_MAX_REG+1];
 /*------------------------Define local variable------------------------------*/
 
 


### PR DESCRIPTION
When compiling rt8192cu with GCC 4.9.x there are several warnings about out of bound accesses to the static RF_Shadow register array, which originate from code lines using <= RF6052_MAX_REG as loop termination criteria. The array's second level size is defined as RF6052_MAX_REG while it (most probably) should be RF6052_MAX_REG+1 to cover all 64 registers.
