### PR TITLE
Resolve couple of gcc complains

### DIFF
--- a/hal/rtl8192c/rtl8192c_rf6052.c
+++ b/hal/rtl8192c/rtl8192c_rf6052.c
@@ -1015,7 +1015,7 @@ PHY_RFShadowRefresh(
 
 	for (eRFPath = 0; eRFPath < RF6052_MAX_PATH; eRFPath++)
 	{
-		for (Offset = 0; Offset <= RF6052_MAX_REG; Offset++)
+		for (Offset = 0; Offset < RF6052_MAX_REG; Offset++)
 		{
 			RF_Shadow[eRFPath][Offset].Value = 0;
 			RF_Shadow[eRFPath][Offset].Compare = _FALSE;

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -226,7 +226,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 {
 	int cmd_num;
 	for(cmd_num=0 ; cmd_num<ANDROID_WIFI_CMD_MAX; cmd_num++)
-		if(0 == strnicmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
+		if(0 == strncasecmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
 			break;
 		
 	return cmd_num;


### PR DESCRIPTION
When compiling with 4.1, gcc has 3 complains. In this pull request I fix two of them. One in particular looks like a bug: as an array is written beyond its last element.

The third complain relates to the use of the macros DATE and TIME. I resolved it locally adding in the Makefile a flag to ignore the warning, however this is not part of this pull request, as I noticed there is another pull request at this purpose.