### PR TITLE
Fix compilation for recent kernels

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -786,6 +786,10 @@ __inline static void _set_workitem(_workitem *pwork)
 	#include <linux/interrupt.h>	// for struct tasklet_struct
 	#include <linux/ip.h>
 	#include <linux/kthread.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
+	#include <linux/signal.h>
+	#include <linux/sched/signal.h>
+#endif
 
 #ifdef CONFIG_IOCTL_CFG80211	
 //	#include <linux/ieee80211.h>        

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -978,7 +978,13 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+                            void *accel_priv,
+                            select_queue_fallback_t fallback)
+#else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb)
+#endif
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;


### PR DESCRIPTION
This applies two patches that fixes warnings, and fixes compilation for 4.11 kernels.